### PR TITLE
Remove version number from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "finanzcheck/change-logger-behavior",
-  "version": "2.0.0",
   "description": "A behavior allowing you to log one or more columns in a extra logging table like the versionable behavior for Propel2.",
   "require": {
     "propel/propel": ">=2.0.0-beta2",


### PR DESCRIPTION
This allows us to publish new versions without having to remember to
bump the version number here.
